### PR TITLE
Add falcond profiles for X4 and Factorio

### DIFF
--- a/usr/share/falcond/profiles/factorio.conf
+++ b/usr/share/falcond/profiles/factorio.conf
@@ -1,0 +1,5 @@
+name = "factorio"
+performance_mode = true
+scx_sched = none
+vcache_mode = cache
+idle_inhibit = true

--- a/usr/share/falcond/profiles/x4.conf
+++ b/usr/share/falcond/profiles/x4.conf
@@ -1,0 +1,5 @@
+name = "X4"
+performance_mode = true
+scx_sched = none
+vcache_mode = cache
+idle_inhibit = true


### PR DESCRIPTION
Add falcond profiles for X4: Foundations and Factorio.

Both games benefit from performance mode and idle inhibit.
Tested locally on PikaOS.